### PR TITLE
add TTS support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ venv
 launch-peung.sh
 assets/
 __pycache__/
+src/peung/pygame

--- a/README.md
+++ b/README.md
@@ -1,36 +1,23 @@
 Note: Detecting mouse input does not seem to work on Wayland. Use Xorg.
 
+## TTS and sound assets
+
+When Peung runs, it will make the sound asset directory (if it does not exist) and tell you where this is.
+If a sound file exists, peung will use it. If it does not exist, a text-to-speech file will be made for the sound.
+The TTS audio file can then be replaced with custom audio if desired.
+
 ## Getting sound assets
 
 If you have access, download [the sound assets here](https://drive.google.com/file/d/1Ky-RoYqmEFlRVsw-29jSYjuCZUNRZ-Xt/view?usp=drive_link).
-Run peung once to get an error message that informs you of where the application data directory is. 
 Extract the assets into the application data directory.
 
-If you don't have access, you will have to create sound files like this in the application data directory.
-```txt
-assets/serve_0.mp3
-assets/serve_1.mp3
-assets/win_0.mp3
-assets/win_1.mp3
-assets/serve_[PLAYERNAME].mp3
-assets/win_[PLAYERNAME].mp3
-assets/num_[#].mp3
-assets/game_score.mp3
-assets/match_score.mp3
-assets/the_match.mp3
-assets/factorio.mp3
-assets/match_factorio.mp3
-assets/deuce.mp3
-assets/peuped.mp3
-assets/you_peuped.mp3
-```
-where
-- `[PLAYERNAME]` can be replaced by special player names with their own unique sounds; these are optional
-- `[#]` should be replaced by integers starting from 1, so `num_1.mp3`, `num_2.mp3`, etc. to announce scores.
+## Optional chimes
+
+Three "chimes" currently are optional, and will play only if the corresponding file already exists in the assets directory - "undo_chime.mp3", "victory_chime.mp3", and "grand_victory_chime.mp3".
 
 ## Disabling mouse movement
 
-One issue with this program is that mouse clicks captured by the program are
+One issue with peung is that mouse clicks captured by the program are
 still sent to other applications. This results in an annoying right click menu
 that needs to be dodged.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,7 @@ dependencies = [
   "pygame",
   "pynput",
   "platformdirs",
+  "gtts",
 ]
 
 [project.urls]

--- a/src/peung/peung.py
+++ b/src/peung/peung.py
@@ -21,9 +21,8 @@ def play_sound(phrase,skip_if_missing=False):
   if not filepath.exists():
     if skip_if_missing:
       return
-    else:
-      tts = gTTS(phrase)
-      tts.save(sound_assets_dir/to_filename(phrase))
+    tts = gTTS(phrase)
+    tts.save(sound_assets_dir/to_filename(phrase))
   pygame.mixer.music.load(filepath)
   pygame.mixer.music.play()
   while pygame.mixer.music.get_busy():
@@ -31,7 +30,7 @@ def play_sound(phrase,skip_if_missing=False):
 
 def say_num(num):
   num_prefix = "" if not QLUMB_MODE else "q"
-  play_sound(num_prefix+str(num))
+  play_sound(f"{num_prefix}{num}")
 
 def to_filename(phrase):
   return phrase.replace(" ", "_")+".mp3"
@@ -47,17 +46,15 @@ class Game:
 
   def report(self):
     for i in range(2):
-      print(self.player[i]+": "+str(self.score[i]))
-    print(self.player[self.server]+" serve")
+      print(f"{self.player[i]}: {self.score[i]}")
+    print(f"{self.player[self.server]} serve")
 
     if sum(self.score)==0:
       play_sound("game score")
 
     say_num(self.score[0])
-    #sleep(0.2)
     say_num(self.score[1])
-    #sleep(0.65)
-    play_sound(str(self.player[self.server])+" serve")
+    play_sound(f"{self.player[self.server]} serve")
 
   def next(self):
     set_outcome()
@@ -80,18 +77,18 @@ class Game:
       play_sound("undo")
     else:
       play_sound("undo")
-      play_sound("undo chime",True)
+      play_sound("undo chime",skip_if_missing=True)
       self.__dict__ = self.previous.__dict__
 
   def play(self):
     while abs(self.score[0]-self.score[1])<2 or max([self.score[0],self.score[1]]) < GAME_LENGTH:
-      print("Left click if "+self.player[0]+" scores and right click if "+self.player[1]+" scores. Middle click to undo.\n")
+      print(f"Left click if {self.player[0]} scores and right click if {self.player[1]} scores. Middle click to undo.\n")
       self.report()
       self.next()
     
     winner = 0 if self.score[0] > self.score[1] else 1
-    play_sound(str(self.player[winner])+" win")
-    play_sound("victory chime",True)
+    play_sound(f"{self.player[winner]} win")
+    play_sound("victory chime",skip_if_missing=True)
     return winner
 
     
@@ -130,16 +127,13 @@ def main():
     game = Game(player)
     play_sound("match score")
     say_num(match_score[0])
-    #sleep(0.2)
     say_num(match_score[1])
-    #sleep(0.65)
     match_score[game.play()] += 1
 
   match_winner = 0 if match_score[0] > match_score[1] else 1
-  play_sound(str(player[match_winner])+" win")
-  #sleep(0.5)
+  play_sound(f"{player[match_winner]} win")
   play_sound("the match that is")
-  play_sound("grand victory chime",True)
+  play_sound("grand victory chime",skip_if_missing=True)
 
 if __name__=="__main__":
   main()

--- a/src/peung/peung.py
+++ b/src/peung/peung.py
@@ -3,10 +3,9 @@ from pynput import mouse
 from time import sleep
 from pathlib import Path
 from platformdirs import user_data_dir
+from gtts import gTTS
 
-MAX_SOUND_FILE = 30 # maximum score for which a recording exists
 QLUMB_MODE = False # toggle qlumbers
-SPECIAL_PLAYERS = ["heddood", "yusuf", "yussra", "mama", "baba"]
 GAME_LENGTH = 11 # number of rallies in a game
 
 OUTCOME_MAPPING = {
@@ -17,23 +16,25 @@ OUTCOME_MAPPING = {
 
 sound_assets_dir = Path(user_data_dir("peung")) / "assets"
 
-
-def play_sound(filename):
-  filepath = sound_assets_dir/filename
+def play_sound(phrase,skip_if_missing=False):
+  filepath = sound_assets_dir/to_filename(phrase)
   if not filepath.exists():
-    if not sound_assets_dir.is_dir():
-      raise FileNotFoundError(f"Please obtain and extract sounds to {sound_assets_dir}")
-    if not filepath.exists():
-      raise FileNotFoundError(f"Missing sound: {filepath}")
+    if skip_if_missing:
+      return
+    else:
+      tts = gTTS(phrase)
+      tts.save(str(sound_assets_dir)+"/"+to_filename(phrase))
   pygame.mixer.music.load(filepath)
   pygame.mixer.music.play()
   while pygame.mixer.music.get_busy():
     pygame.time.Clock().tick(10)
 
 def say_num(num):
-  num_prefix = "num" if not QLUMB_MODE else "qlum"
-  play_sound(num_prefix+"_"+str(num)+".mp3")
+  num_prefix = "" if not QLUMB_MODE else "q"
+  play_sound(num_prefix+str(num))
 
+def to_filename(phrase):
+  return phrase.replace(" ", "_")+".mp3"
 
 class Game:
 
@@ -47,20 +48,16 @@ class Game:
   def report(self):
     for i in range(2):
       print(self.player[i]+": "+str(self.score[i]))
-    print(self.player[self.server]+"'s serve.")
+    print(self.player[self.server]+" serve")
 
     if sum(self.score)==0:
-      play_sound("game_score.mp3")
+      play_sound("game score")
 
-    if max(self.score) <= MAX_SOUND_FILE:
-      say_num(self.score[0])
-      sleep(0.2)
-      say_num(self.score[1])
-    sleep(0.65)
-    if self.player[self.server] in SPECIAL_PLAYERS:
-      play_sound("serve_"+str(self.player[self.server])+".mp3")
-    else:
-      play_sound("serve_"+str(self.server)+".mp3")
+    say_num(self.score[0])
+    #sleep(0.2)
+    say_num(self.score[1])
+    #sleep(0.65)
+    play_sound(str(self.player[self.server])+" serve")
 
   def next(self):
     set_outcome()
@@ -71,7 +68,7 @@ class Game:
       self.score[outcome]+=1
       if self.score[0]==GAME_LENGTH-1 and self.score[1]==GAME_LENGTH-1:
         self.deuce = True
-        play_sound("deuce.mp3")
+        play_sound("deuce")
       if self.serve_counter == 1 or self.deuce:
         self.server = 1 if self.server == 0 else 0
         self.serve_counter = 0
@@ -80,10 +77,10 @@ class Game:
   
   def undo(self):
     if "previous" not in self.__dict__.keys():
-      play_sound("you_peuped.mp3")
+      play_sound("undo")
     else:
-      play_sound("you_peuped.mp3")
-      play_sound("peuped.mp3")
+      play_sound("undo")
+      play_sound("undo chime",True)
       self.__dict__ = self.previous.__dict__
 
   def play(self):
@@ -93,11 +90,8 @@ class Game:
       self.next()
     
     winner = 0 if self.score[0] > self.score[1] else 1
-    if self.player[winner] in SPECIAL_PLAYERS:
-      play_sound("win_"+str(self.player[winner])+".mp3")
-    else:
-      play_sound("win_"+str(winner)+".mp3")
-    play_sound("factorio.mp3")
+    play_sound(str(self.player[winner])+" win")
+    play_sound("victory chime",True)
     return winner
 
     
@@ -116,6 +110,11 @@ def set_outcome():
 def main():
   pygame.init()
   pygame.mixer.init()
+
+  if not sound_assets_dir.is_dir():
+    sound_assets_dir.mkdir(parents=True,mode=0o755)
+
+  print(f"Sound asset directory: {sound_assets_dir}")
   print("How many games in this match?")
   num_games = int(input())
   if num_games%2==0: num_games+=1
@@ -129,21 +128,18 @@ def main():
 
   while max(match_score) <= num_games/2:
     game = Game(player)
-    play_sound("match_score.mp3")
+    play_sound("match score")
     say_num(match_score[0])
-    sleep(0.2)
+    #sleep(0.2)
     say_num(match_score[1])
-    sleep(0.65)
+    #sleep(0.65)
     match_score[game.play()] += 1
 
   match_winner = 0 if match_score[0] > match_score[1] else 1
-  if player[match_winner] in SPECIAL_PLAYERS:
-    play_sound("win_"+str(player[match_winner])+".mp3")
-  else:
-    play_sound("win_"+str(match_winner)+".mp3")
-  sleep(0.5)
-  play_sound("the_match.mp3")
-  play_sound("match_factorio.mp3")
+  play_sound(str(player[match_winner])+" win")
+  #sleep(0.5)
+  play_sound("the match that is")
+  play_sound("grand victory chime",True)
 
 if __name__=="__main__":
   main()

--- a/src/peung/peung.py
+++ b/src/peung/peung.py
@@ -23,7 +23,7 @@ def play_sound(phrase,skip_if_missing=False):
       return
     else:
       tts = gTTS(phrase)
-      tts.save(str(sound_assets_dir)+"/"+to_filename(phrase))
+      tts.save(sound_assets_dir/to_filename(phrase))
   pygame.mixer.music.load(filepath)
   pygame.mixer.music.play()
   while pygame.mixer.music.get_busy():


### PR DESCRIPTION
See #4 

TTS support added here.
Enjoy this thick, chunky commit soup...Pertinent changes below:

* In play_sound(), if the file does not exist, the function will now use gTTS to make it.
  * That is unless the argument skip_if_missing is True, in which case the sound will just be skipped. This argument is true for only the 3 "chime" sounds currently - the undo chime, the victory chime, and the grand victory chime.
* A standard conversion is used between the spoken phrase and the filename, done by the new function to_filename() -- spaces are replaced with underscores, and ".mp3" is appended.
  * The number files are also just the number now. Qlumbers are "q"+number (e.g. q1.mp3).
  * Accordingly, the standard custom assets we use had to be renamed, which was done in the google drive (updated with the "manage versions" feature).
* Removed now-unnecessary consts MAX_SOUND_FILE and SPECIAL_PLAYERS, and code that used these consts. This somewhat simplified a lot of code!
* Since files should never be missing now, the method of informing the user of the directory location has changed. Now, peung looks for the asset directory when it runs, creates it if it does not already exist, and tells the user where it is.
  * There may be a better way we can set this up - not sure the user needs to get bombarded with the asset directory location every time they run peung. However, maybe this will also be a non-problem as we shift to Qt and can just make it a button somewhere.
* Updated README.md to reflect how TTS works here.